### PR TITLE
Fix CDN link

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
         <link href="https://fonts.googleapis.com/css2?family=Jost:wght@400;700&display=swap" rel="stylesheet" />
         <link rel="stylesheet" href="styles.css" />
         <script src="https://unpkg.com/vue@next" defer></script>
+        <script src="https://unpkg.com/vue" defer></script>
         <script src="app.js" defer></script>
     </head>
     <body>


### PR DESCRIPTION
- Turn off speech
- Add manual TTS trigger as a workaround for Safari
- Add global event listener as a workaround
- Move enable TTS to a button
- Keep button only
- Restore speech
- Set en-GB explicitly
- Add family and pets
- Update README.md
- Hide family and pets
- Update CDN link
